### PR TITLE
Mac の rm コマンドサポート

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -246,7 +246,7 @@ impl Language for Rust {
             ),
             CompileStep::new(
                 "rm".to_string(),
-                vec![format!("./{}", self.problem_name), "-f".to_string()],
+                vec!["-f".to_string(), format!("./{}", self.problem_name)],
                 None,
             ),
             CompileStep::new(


### PR DESCRIPTION
* Mac の rm コマンドはオプションをファイル名より先に指定しないといけないため

例:
```
❯ touch hoge
# hogeファイル作成
❯ rm hoge -f
rm: -f: No such file or directory
# hoge と -f を削除しようとしている
# hogeファイルは削除される
❯ rm -f hoge
# hoge ファイルは削除されているが -f オプションが効いているのでエラーにならない
```