### PR TITLE
バージョン0.1.1向け準備

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pahcer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pahcer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["terry_u16"]
 description = "A tool to run tests for AtCoder Heuristic Contest (AHC)"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -121,7 +121,7 @@ pub(crate) fn gen_setting_file(args: &InitArgs) -> Result<()> {
         "Failed to create the setting file. Ensure that ./pahcer_config.toml does not exist.",
     )?);
 
-    let version = "0.1.0".to_string();
+    let version = env!("CARGO_PKG_VERSION").to_string();
     let general = General::new(version);
 
     let lang: Box<dyn Language> = match args.langage {


### PR DESCRIPTION
バージョン0.1.1向け準備を行った。

- Cargo.tomlのバージョンを変更
- `env!("CARGO_PKG_VERSION")` で `pahcer_config.toml` に自動反映されるように変更