### PR TITLE
出力フォーマットの桁数を増加

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 pub(crate) mod runner;
 pub(crate) mod settings;
+pub(crate) mod util;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/src/runner/io.rs
+++ b/src/runner/io.rs
@@ -11,7 +11,7 @@ use std::{
     ffi::OsStr,
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Write},
-    num::NonZeroU64,
+    num::{NonZeroU64, NonZeroUsize},
     path::{Path, PathBuf},
 };
 
@@ -96,11 +96,11 @@ pub(super) fn save_summary_log(
 fn save_summary_header(writer: &mut impl Write) -> Result<()> {
     writeln!(
         writer,
-        "Time                      | Cases  | Total Score       | Average Score | Total log10 | Average log10 | Comment"
+        "Time                      | Cases | Total Score      | Avg. Score       | Total log10  | Avg. log10  | Comment"
     )?;
     writeln!(
         writer,
-        "--------------------------|-------:|------------------:|--------------:|------------:|--------------:|----------------------"
+        "--------------------------|------:|-----------------:|-----------------:|-------------:|------------:|----------------------"
     )?;
 
     Ok(())
@@ -111,24 +111,64 @@ fn save_summary_log_inner(
     stats: &multi::TestStats,
     comment: &str,
 ) -> Result<()> {
+    let nonzero2 = NonZeroUsize::new(2).unwrap();
+    let nonzero5 = NonZeroUsize::new(5).unwrap();
+
     let start_time = stats
         .start_time
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let case_count = stats.results.len().to_formatted_string(&Locale::en);
     let score = stats.score_sum.to_formatted_string(&Locale::en);
-    let average_score = ((stats.score_sum as f64 / stats.results.len() as f64).round() as u64)
-        .to_formatted_string(&Locale::en);
+    let average_score = format_float_with_commas(
+        stats.score_sum as f64 / stats.results.len() as f64,
+        nonzero2,
+    );
 
-    let score_log10 = stats.score_sum_log10;
-    let average_score_log10 = stats.score_sum_log10 / stats.results.len() as f64;
+    let score_log10 = format_float_with_commas(stats.score_sum_log10, nonzero5);
+    let average_score_log10 =
+        format_float_with_commas(stats.score_sum_log10 / stats.results.len() as f64, nonzero5);
 
     writeln!(
         writer,
-        "{} | {:>6} | {:>17} | {:>13} | {:>11.3} | {:>13.3} | {}",
+        "{} | {:>5} | {:>16} | {:>16} | {:>12} | {:>11} | {}",
         start_time, case_count, score, average_score, score_log10, average_score_log10, comment
     )?;
 
     Ok(())
+}
+
+/// 浮動小数点数 `x` を、整数部を3桁区切りしつつ小数点以下を `decimals` 桁に丸めて文字列化します。
+/// 負の0 (`-0.0`) を含む負数でも符号を正しく付加し、大きな整数部も `i64` の範囲で処理します。
+fn format_float_with_commas(x: f64, decimals: NonZeroUsize) -> String {
+    // 桁数（>= 1）
+    let decimals = decimals.get();
+
+    // 符号を保持
+    let is_negative = x.is_sign_negative();
+
+    // 絶対値を指定桁数で文字列化
+    // ここで decimals は必ず 1 以上
+    let abs_str = format!("{:.*}", decimals, x.abs());
+
+    // 小数点で分割（decimals >= 1 なので必ず小数点は存在する）
+    let (int_part, frac_part) = abs_str.split_once('.').unwrap();
+
+    // 整数部を i64 にパースしてカンマ区切り
+    // （非常に大きい場合は BigInt などを検討）
+    let int_formatted = int_part
+        .parse::<i64>()
+        .unwrap()
+        .to_formatted_string(&Locale::en);
+
+    // 整数部と小数部を再連結
+    let result = format!("{}.{}", int_formatted, frac_part);
+
+    // 負数なら符号を付けて返す
+    if is_negative {
+        format!("-{}", result)
+    } else {
+        result
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -257,6 +297,49 @@ mod test {
     use std::{num::NonZero, time::Duration};
 
     #[test]
+    fn test_format_float_with_commas_basic() {
+        let decimals1 = NonZeroUsize::new(1).unwrap();
+        let decimals3 = NonZeroUsize::new(3).unwrap();
+
+        // 正の数, 小数点以下1桁
+        assert_eq!(format_float_with_commas(12345.6789, decimals1), "12,345.7");
+        // 負の数, 小数点以下1桁
+        assert_eq!(format_float_with_commas(-0.1, decimals1), "-0.1");
+
+        // 正の数, 小数点以下3桁 (繰り上がりが発生)
+        // 12,345.6789 → 12,345.679
+        assert_eq!(
+            format_float_with_commas(12345.6789, decimals3),
+            "12,345.679"
+        );
+
+        // 負の数, 小数点以下3桁, 非常に小さい値
+        // -0.0004 → -0.000 (丸め)
+        assert_eq!(format_float_with_commas(-0.0004, decimals3), "-0.000");
+
+        // 負の0 (is_sign_negative が true となる -0.0)
+        // 小数点以下3桁 → -0.000
+        assert_eq!(format_float_with_commas(-0.0, decimals3), "-0.000");
+    }
+
+    #[test]
+    fn test_format_float_with_commas_large() {
+        let decimals3 = NonZeroUsize::new(3).unwrap();
+
+        // 非常に大きい数で繰り上がりあり (999,999,999.9999 → 1,000,000,000.000)
+        assert_eq!(
+            format_float_with_commas(999999999.9999, decimals3),
+            "1,000,000,000.000"
+        );
+
+        // 10桁以上の数
+        assert_eq!(
+            format_float_with_commas(1234567890123.001, decimals3),
+            "1,234,567,890,123.001"
+        );
+    }
+
+    #[test]
     fn save_summary_log_no_file() -> Result<()> {
         let mut buf = vec![];
         let start_time = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
@@ -283,9 +366,9 @@ mod test {
         save_summary_log_inner(&mut buf, &stats, "hoge")?;
 
         let expected = format!(
-"Time                      | Cases  | Total Score       | Average Score | Total log10 | Average log10 | Comment
---------------------------|-------:|------------------:|--------------:|------------:|--------------:|----------------------
-{} |      2 |            11,000 |         5,500 |       7.000 |         3.500 | hoge
+"Time                      | Cases | Total Score      | Avg. Score       | Total log10  | Avg. log10  | Comment
+--------------------------|------:|-----------------:|-----------------:|-------------:|------------:|----------------------
+{} |     2 |           11,000 |         5,500.00 |      7.00000 |     3.50000 | hoge
 ", start_time.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
 
         let actual = String::from_utf8(buf).unwrap();

--- a/src/runner/io.rs
+++ b/src/runner/io.rs
@@ -1,3 +1,5 @@
+use crate::util::format_float_with_commas;
+
 use super::{
     multi::{self, TestStats},
     Settings,
@@ -137,40 +139,6 @@ fn save_summary_log_inner(
     Ok(())
 }
 
-/// 浮動小数点数 `x` を、整数部を3桁区切りしつつ小数点以下を `decimals` 桁に丸めて文字列化します。
-/// 負の0 (`-0.0`) を含む負数でも符号を正しく付加し、大きな整数部も `i64` の範囲で処理します。
-fn format_float_with_commas(x: f64, decimals: NonZeroUsize) -> String {
-    // 桁数（>= 1）
-    let decimals = decimals.get();
-
-    // 符号を保持
-    let is_negative = x.is_sign_negative();
-
-    // 絶対値を指定桁数で文字列化
-    // ここで decimals は必ず 1 以上
-    let abs_str = format!("{:.*}", decimals, x.abs());
-
-    // 小数点で分割（decimals >= 1 なので必ず小数点は存在する）
-    let (int_part, frac_part) = abs_str.split_once('.').unwrap();
-
-    // 整数部を i64 にパースしてカンマ区切り
-    // （非常に大きい場合は BigInt などを検討）
-    let int_formatted = int_part
-        .parse::<i64>()
-        .unwrap()
-        .to_formatted_string(&Locale::en);
-
-    // 整数部と小数部を再連結
-    let result = format!("{}.{}", int_formatted, frac_part);
-
-    // 負数なら符号を付けて返す
-    if is_negative {
-        format!("-{}", result)
-    } else {
-        result
-    }
-}
-
 #[derive(Debug, Clone, Serialize)]
 struct AllResultJson<'a> {
     start_time: DateTime<Local>,
@@ -295,49 +263,6 @@ mod test {
     use crate::runner::single::{Objective, TestCase, TestResult};
     use chrono::DateTime;
     use std::{num::NonZero, time::Duration};
-
-    #[test]
-    fn test_format_float_with_commas_basic() {
-        let decimals1 = NonZeroUsize::new(1).unwrap();
-        let decimals3 = NonZeroUsize::new(3).unwrap();
-
-        // 正の数, 小数点以下1桁
-        assert_eq!(format_float_with_commas(12345.6789, decimals1), "12,345.7");
-        // 負の数, 小数点以下1桁
-        assert_eq!(format_float_with_commas(-0.1, decimals1), "-0.1");
-
-        // 正の数, 小数点以下3桁 (繰り上がりが発生)
-        // 12,345.6789 → 12,345.679
-        assert_eq!(
-            format_float_with_commas(12345.6789, decimals3),
-            "12,345.679"
-        );
-
-        // 負の数, 小数点以下3桁, 非常に小さい値
-        // -0.0004 → -0.000 (丸め)
-        assert_eq!(format_float_with_commas(-0.0004, decimals3), "-0.000");
-
-        // 負の0 (is_sign_negative が true となる -0.0)
-        // 小数点以下3桁 → -0.000
-        assert_eq!(format_float_with_commas(-0.0, decimals3), "-0.000");
-    }
-
-    #[test]
-    fn test_format_float_with_commas_large() {
-        let decimals3 = NonZeroUsize::new(3).unwrap();
-
-        // 非常に大きい数で繰り上がりあり (999,999,999.9999 → 1,000,000,000.000)
-        assert_eq!(
-            format_float_with_commas(999999999.9999, decimals3),
-            "1,000,000,000.000"
-        );
-
-        // 10桁以上の数
-        assert_eq!(
-            format_float_with_commas(1234567890123.001, decimals3),
-            "1,234,567,890,123.001"
-        );
-    }
 
     #[test]
     fn save_summary_log_no_file() -> Result<()> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,85 @@
+use std::num::NonZeroUsize;
+
+use num_format::{Locale, ToFormattedString as _};
+
+/// 浮動小数点数 `x` を、整数部を3桁区切りしつつ小数点以下を `decimals` 桁に丸めて文字列化します。
+/// 負の0 (`-0.0`) を含む負数でも符号を正しく付加し、大きな整数部も `i64` の範囲で処理します。
+pub(crate) fn format_float_with_commas(x: f64, decimals: NonZeroUsize) -> String {
+    // 桁数（>= 1）
+    let decimals = decimals.get();
+
+    // 符号を保持
+    let is_negative = x.is_sign_negative();
+
+    // 絶対値を指定桁数で文字列化
+    // ここで decimals は必ず 1 以上
+    let abs_str = format!("{:.*}", decimals, x.abs());
+
+    // 小数点で分割（decimals >= 1 なので必ず小数点は存在する）
+    let (int_part, frac_part) = abs_str.split_once('.').unwrap();
+
+    // 整数部を i64 にパースしてカンマ区切り
+    // （非常に大きい場合は BigInt などを検討）
+    let int_formatted = int_part
+        .parse::<i64>()
+        .unwrap()
+        .to_formatted_string(&Locale::en);
+
+    // 整数部と小数部を再連結
+    let result = format!("{}.{}", int_formatted, frac_part);
+
+    // 負数なら符号を付けて返す
+    if is_negative {
+        format!("-{}", result)
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_format_float_with_commas_basic() {
+        let decimals1 = NonZeroUsize::new(1).unwrap();
+        let decimals3 = NonZeroUsize::new(3).unwrap();
+
+        // 正の数, 小数点以下1桁
+        assert_eq!(format_float_with_commas(12345.6789, decimals1), "12,345.7");
+        // 負の数, 小数点以下1桁
+        assert_eq!(format_float_with_commas(-0.1, decimals1), "-0.1");
+
+        // 正の数, 小数点以下3桁 (繰り上がりが発生)
+        // 12,345.6789 → 12,345.679
+        assert_eq!(
+            format_float_with_commas(12345.6789, decimals3),
+            "12,345.679"
+        );
+
+        // 負の数, 小数点以下3桁, 非常に小さい値
+        // -0.0004 → -0.000 (丸め)
+        assert_eq!(format_float_with_commas(-0.0004, decimals3), "-0.000");
+
+        // 負の0 (is_sign_negative が true となる -0.0)
+        // 小数点以下3桁 → -0.000
+        assert_eq!(format_float_with_commas(-0.0, decimals3), "-0.000");
+    }
+
+    #[test]
+    fn test_format_float_with_commas_large() {
+        let decimals3 = NonZeroUsize::new(3).unwrap();
+
+        // 非常に大きい数で繰り上がりあり (999,999,999.9999 → 1,000,000,000.000)
+        assert_eq!(
+            format_float_with_commas(999999999.9999, decimals3),
+            "1,000,000,000.000"
+        );
+
+        // 10桁以上の数
+        assert_eq!(
+            format_float_with_commas(1234567890123.001, decimals3),
+            "1,234,567,890,123.001"
+        );
+    }
+}


### PR DESCRIPTION
## 背景

現状の出力は全体的に桁数が足りず、特にAHC042のようにスコアが100前後になるような問題だと実行ごとの平均スコアの違いが分かりづらいという問題が発生していた。

## 修正点

以下のように、平均スコア・対数スコアの桁数を増やして表示するようにした。

- コンソール出力
  - 表中の `case` を削除（冗長な情報だったため）
  - 表中の `Average Score` を小数点以下第2位まで表示
  - サマリの `Average Score` を小数点以下第2位まで表示
  - サマリの `Average Score (log10)` を小数点以下第5位まで表示（以前は第3位まで）
- summary.md
  - `Avg. Score` を小数点以下第2位まで表示
  - `Total log10` を小数点以下第5位まで表示（以前は第3位まで）
  - `Average log10` を小数点以下第5位まで表示（以前は第3位まで）

## 出力例

### コンソール出力

#### Before

```text
|  Progress  | Seed |     Case Score      |    Average Score    |   Exec.   |
|            |      |  Score   | Relative |  Score   | Relative |   Time    |
|------------|------|----------|----------|----------|----------|-----------|
| case 1 / 3 | 0000 |    1,000 | 1000.000 |    1,000 | 1000.000 |  1,234 ms |
| case 2 / 3 | 0001 |      500 |  500.000 |      750 |  750.000 | 12,345 ms |
| case 3 / 3 | 0002 |        0 |    0.000 |      500 |  500.000 |      1 ms |
error
Average Score          : 500
Average Score (log10)  : 1.900
Average Relative Score : 500.000
Accepted               : 2 / 3
Max Execution Time     : 12,345 ms
```

#### After

```text
| Progress  | Seed |     Case Score      |     Average Score      |   Exec.   |
|           |      |  Score   | Relative |    Score    | Relative |   Time    |
|-----------|------|----------|----------|-------------|----------|-----------|
|   1 /   3 | 0000 |    1,000 | 1000.000 |    1,000.00 | 1000.000 |  1,234 ms |
|   2 /   3 | 0001 |      500 |  500.000 |      750.00 |  750.000 | 12,345 ms |
|   3 /   3 | 0002 |        0 |    0.000 |      500.00 |  500.000 |      1 ms |
error
Average Score          : 500.00
Average Score (log10)  : 1.89966
Average Relative Score : 500.000
Accepted               : 2 / 3
Max Execution Time     : 12,345 ms
```

### summary.md

#### Before

```text
Time                      | Cases  | Total Score       | Average Score | Total log10 | Average log10 | Comment
--------------------------|-------:|------------------:|--------------:|------------:|--------------:|----------------------
2024-01-01T09:00:00+09:00 |      2 |            11,000 |         5,500 |       7.000 |         3.500 | hoge
```

#### After

```text
Time                      | Cases | Total Score      | Avg. Score       | Total log10  | Avg. log10  | Comment
--------------------------|------:|-----------------:|-----------------:|-------------:|------------:|----------------------
2024-01-01T09:00:00+09:00 |     2 |           11,000 |         5,500.00 |      7.00000 |     3.50000 | hoge
```
