### PR TITLE
toolsを事前コンパイルするよう変更

### DIFF
--- a/src/settings/linux/cpp.toml
+++ b/src/settings/linux/cpp.toml
@@ -7,6 +7,22 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./vis"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/vis", "./vis"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
@@ -22,14 +38,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/linux/cpp_interactive.toml
+++ b/src/settings/linux/cpp_interactive.toml
@@ -7,15 +7,30 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./tester"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/tester", "./tester"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../a.out"]
-current_dir = "./tools"
+program = "./tester"
+args = ["./a.out"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/linux/go.toml
+++ b/src/settings/linux/go.toml
@@ -7,6 +7,22 @@
 program = "go"
 args = ["build", "-o", "a.out", "main.go"]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./vis"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/vis", "./vis"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
@@ -22,14 +38,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/linux/go_interactive.toml
+++ b/src/settings/linux/go_interactive.toml
@@ -7,15 +7,30 @@
 program = "go"
 args = ["build", "-o", "a.out", "main.go"]
 
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./tester"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/tester", "./tester"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../a.out"]
-current_dir = "./tools"
+program = "./tester"
+args = ["./a.out"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/linux/python.toml
+++ b/src/settings/linux/python.toml
@@ -2,8 +2,21 @@
 #         COMPILE STEPS
 # ==============================
 
-# You don't need to compile anything for Python
-compile_steps = []
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./vis"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/vis", "./vis"]
 
 # ==============================
 #           TEST STEPS
@@ -20,14 +33,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/linux/python_interactive.toml
+++ b/src/settings/linux/python_interactive.toml
@@ -2,8 +2,21 @@
 #         COMPILE STEPS
 # ==============================
 
-# You don't need to compile anything for Python
-compile_steps = []
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./tester"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/tester", "./tester"]
 
 # ==============================
 #           TEST STEPS
@@ -11,9 +24,8 @@ compile_steps = []
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "python3", "../main.py"]
-current_dir = "./tools"
+program = "./tester"
+args = ["python3", "./main.py"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/linux/rust.toml
+++ b/src/settings/linux/rust.toml
@@ -17,6 +17,22 @@ args = ["-f", "./{PROBLEM_NAME}"]
 program = "mv"
 args = ["./target/release/{PROBLEM_NAME}", "./{PROBLEM_NAME}"]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./vis"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/vis", "./vis"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
@@ -32,14 +48,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/linux/rust_interactive.toml
+++ b/src/settings/linux/rust_interactive.toml
@@ -17,15 +17,30 @@ args = ["-f", "./{PROBLEM_NAME}"]
 program = "mv"
 args = ["./target/release/{PROBLEM_NAME}", "./{PROBLEM_NAME}"]
 
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Remove the old tester
+[[test.compile_steps]]
+program = "rm"
+args = ["-f", "./tester"]
+
+# Move the tester to the current directory
+[[test.compile_steps]]
+program = "mv"
+args = ["./tools/target/release/tester", "./tester"]
+
 # ==============================
 #           TEST STEPS
 # ==============================
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../{PROBLEM_NAME}"]
-current_dir = "./tools"
+program = "./tester"
+args = ["./{PROBLEM_NAME}"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/macos/cpp.toml
+++ b/src/settings/macos/cpp.toml
@@ -7,10 +7,6 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the visualizer in advance
-# rather than running it with cargo run every time.
-
 # Compile the visuzlizer
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/cpp_interactive.toml
+++ b/src/settings/macos/cpp_interactive.toml
@@ -7,10 +7,6 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the tester in advance
-# rather than running it with cargo run every time.
-
 # Compile the tester
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/go.toml
+++ b/src/settings/macos/go.toml
@@ -7,10 +7,6 @@
 program = "go"
 args = ["build", "-o", "a.out", "main.go"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the visualizer in advance
-# rather than running it with cargo run every time.
-
 # Compile the visuzlizer
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/go_interactive.toml
+++ b/src/settings/macos/go_interactive.toml
@@ -7,10 +7,6 @@
 program = "go"
 args = ["build", "-o", "a.out", "main.go"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the tester in advance
-# rather than running it with cargo run every time.
-
 # Compile the tester
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/python.toml
+++ b/src/settings/macos/python.toml
@@ -2,10 +2,6 @@
 #         COMPILE STEPS
 # ==============================
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the visualizer in advance
-# rather than running it with cargo run every time.
-
 # Compile the visuzlizer
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/python_interactive.toml
+++ b/src/settings/macos/python_interactive.toml
@@ -2,10 +2,6 @@
 #         COMPILE STEPS
 # ==============================
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the tester in advance
-# rather than running it with cargo run every time.
-
 # Compile the tester
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/rust.toml
+++ b/src/settings/macos/rust.toml
@@ -17,10 +17,6 @@ args = ["-f", "./{PROBLEM_NAME}"]
 program = "mv"
 args = ["./target/release/{PROBLEM_NAME}", "./{PROBLEM_NAME}"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the visualizer in advance
-# rather than running it with cargo run every time.
-
 # Compile the visuzlizer
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/macos/rust_interactive.toml
+++ b/src/settings/macos/rust_interactive.toml
@@ -17,10 +17,6 @@ args = ["-f", "./{PROBLEM_NAME}"]
 program = "mv"
 args = ["./target/release/{PROBLEM_NAME}", "./{PROBLEM_NAME}"]
 
-# On macOS, there’s a possibility of SIGKILL or other issues occurring, 
-# so it’s better to build the tester in advance
-# rather than running it with cargo run every time.
-
 # Compile the tester
 [[test.compile_steps]]
 program = "cargo"

--- a/src/settings/windows/cpp.toml
+++ b/src/settings/windows/cpp.toml
@@ -7,13 +7,27 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = [
+    "-Command",
+    "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force",
+]
+
 # ==============================
 #           TEST STEPS
 # ==============================
 
 # Run the user's program
 [[test.test_steps]]
-program = "./a.out"
+program = "./a.exe"
 args = []
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
@@ -22,14 +36,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis.exe"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/windows/cpp.toml
+++ b/src/settings/windows/cpp.toml
@@ -16,10 +16,7 @@ current_dir = "./tools"
 # Move the compiled tester to the current directory (override the old binary)
 [[test.compile_steps]]
 program = "powershell.exe"
-args = [
-    "-Command",
-    "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force",
-]
+args = ["-Command", "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force"]
 
 # ==============================
 #           TEST STEPS

--- a/src/settings/windows/cpp_interactive.toml
+++ b/src/settings/windows/cpp_interactive.toml
@@ -7,15 +7,28 @@
 program = "g++"
 args = ["-std=c++20", "-O2", "main.cpp"]
 
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = [
+    "-Command",
+    "Move-Item ./tools/target/release/tester.exe ./tester.exe -Force",
+]
+
 # ==============================
 #           TEST STEPS
 # ==============================
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../a.out"]
-current_dir = "./tools"
+program = "./tester.exe"
+args = ["./a.exe"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/windows/go.toml
+++ b/src/settings/windows/go.toml
@@ -7,6 +7,17 @@
 program = "go"
 args = ["build", "-o", "a.exe", "main.go"]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = ["-Command", "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force"]
+
 # ==============================
 #           TEST STEPS
 # ==============================

--- a/src/settings/windows/go.toml
+++ b/src/settings/windows/go.toml
@@ -5,7 +5,7 @@
 # Compile the user's program
 [[test.compile_steps]]
 program = "go"
-args = ["build", "-o", "a.out", "main.go"]
+args = ["build", "-o", "a.exe", "main.go"]
 
 # ==============================
 #           TEST STEPS
@@ -13,7 +13,7 @@ args = ["build", "-o", "a.out", "main.go"]
 
 # Run the user's program
 [[test.test_steps]]
-program = "./a.out"
+program = "./a.exe"
 args = []
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
@@ -22,14 +22,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis.exe"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/windows/go_interactive.toml
+++ b/src/settings/windows/go_interactive.toml
@@ -5,7 +5,21 @@
 # Compile the user's program
 [[test.compile_steps]]
 program = "go"
-args = ["build", "-o", "a.out", "main.go"]
+args = ["build", "-o", "a.exe", "main.go"]
+
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = [
+    "-Command",
+    "Move-Item ./tools/target/release/tester.exe ./tester.exe -Force",
+]
 
 # ==============================
 #           TEST STEPS
@@ -13,9 +27,8 @@ args = ["build", "-o", "a.out", "main.go"]
 
 # Run the tester with the user's program
 [[test.test_steps]]
-program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../a.out"]
-current_dir = "./tools"
+program = "./tester.exe"
+args = ["./a.exe"]
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"
 stderr = "./tools/err/{SEED04}.txt"

--- a/src/settings/windows/python.toml
+++ b/src/settings/windows/python.toml
@@ -2,8 +2,16 @@
 #         COMPILE STEPS
 # ==============================
 
-# You don't need to compile anything for Python
-compile_steps = []
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = ["-Command", "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force"]
 
 # ==============================
 #           TEST STEPS

--- a/src/settings/windows/python.toml
+++ b/src/settings/windows/python.toml
@@ -20,14 +20,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis.exe"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/windows/python_interactive.toml
+++ b/src/settings/windows/python_interactive.toml
@@ -2,8 +2,19 @@
 #         COMPILE STEPS
 # ==============================
 
-# You don't need to compile anything for Python
-compile_steps = []
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = [
+    "-Command",
+    "Move-Item ./tools/target/release/tester.exe ./tester.exe -Force",
+]
 
 # ==============================
 #           TEST STEPS

--- a/src/settings/windows/rust.toml
+++ b/src/settings/windows/rust.toml
@@ -30,14 +30,6 @@ measure_time = true
 
 # Run the visualizer to calculate the score
 [[test.test_steps]]
-program = "cargo"
-args = [
-    "run",
-    "--bin",
-    "vis",
-    "--release",
-    "./in/{SEED04}.txt",
-    "./out/{SEED04}.txt",
-]
-current_dir = "./tools"
+program = "./vis.exe"
+args = ["./tools/in/{SEED04}.txt", "./tools/out/{SEED04}.txt"]
 measure_time = false

--- a/src/settings/windows/rust.toml
+++ b/src/settings/windows/rust.toml
@@ -15,6 +15,17 @@ args = [
     "Move-Item ./target/release/{PROBLEM_NAME}.exe ./{PROBLEM_NAME}.exe -Force",
 ]
 
+# Compile the visuzlizer
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "vis"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = ["-Command", "Move-Item ./tools/target/release/vis.exe ./vis.exe -Force"]
+
 # ==============================
 #           TEST STEPS
 # ==============================

--- a/src/settings/windows/rust_interactive.toml
+++ b/src/settings/windows/rust_interactive.toml
@@ -15,6 +15,20 @@ args = [
     "Move-Item ./target/release/{PROBLEM_NAME}.exe ./{PROBLEM_NAME}.exe -Force",
 ]
 
+# Compile the tester
+[[test.compile_steps]]
+program = "cargo"
+args = ["build", "--release", "--bin", "tester"]
+current_dir = "./tools"
+
+# Move the compiled tester to the current directory (override the old binary)
+[[test.compile_steps]]
+program = "powershell.exe"
+args = [
+    "-Command",
+    "Move-Item ./tools/target/release/tester.exe ./tester.exe -Force",
+]
+
 # ==============================
 #           TEST STEPS
 # ==============================


### PR DESCRIPTION
## 変更点

#12 にてmac版はtoolsを事前ビルドするようにしたが、同じ変更をlinux/windowsにも適用した。

逆に動作しなくなるリスクもあるため、問題が発生するまではマージしない方が良いかも。