### PR TITLE
実行ファイルの拡張子を修正

### DIFF
--- a/src/settings/windows/cpp.toml
+++ b/src/settings/windows/cpp.toml
@@ -13,7 +13,7 @@ args = ["-std=c++20", "-O2", "main.cpp"]
 
 # Run the user's program
 [[test.test_steps]]
-program = "./a.out"
+program = "./a.exe"
 args = []
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"

--- a/src/settings/windows/cpp_interactive.toml
+++ b/src/settings/windows/cpp_interactive.toml
@@ -14,7 +14,7 @@ args = ["-std=c++20", "-O2", "main.cpp"]
 # Run the tester with the user's program
 [[test.test_steps]]
 program = "cargo"
-args = ["run", "--bin", "tester", "--release", "../a.out"]
+args = ["run", "--bin", "tester", "--release", "../a.exe"]
 current_dir = "./tools"
 stdin = "./tools/in/{SEED04}.txt"
 stdout = "./tools/out/{SEED04}.txt"


### PR DESCRIPTION
WindowsでC++をコンパイルすると、生成された実行ファイルの拡張子が.outではなく.exeになります。[参考](https://stackoverflow.com/questions/47377488/why-i-get-an-a-exe-instead-of-a-out-on-window-c-programming)
