### PR TITLE
エラー落ちした場合もファイル出力するように変更

### DIFF
--- a/src/runner/single.rs
+++ b/src/runner/single.rs
@@ -218,13 +218,6 @@ impl SingleCaseRunner {
             .with_context(|| format!("Failed to run. command: {:?}", cmd))?;
         let execution_time = since.elapsed();
 
-        anyhow::ensure!(
-            output.status.success(),
-            "Failed to run ({}). command: {:?}",
-            output.status,
-            cmd
-        );
-
         if let Some(stdout) = &step.stdout {
             let stdout = Self::replace_placeholder(stdout, seed);
             Self::write_output(Path::new(&stdout), &output.stdout)
@@ -239,6 +232,13 @@ impl SingleCaseRunner {
 
         outputs.push(output.stdout);
         outputs.push(output.stderr);
+
+        anyhow::ensure!(
+            output.status.success(),
+            "Failed to run ({}). command: {:?}",
+            output.status,
+            cmd
+        );
 
         Ok(execution_time)
     }


### PR DESCRIPTION
ユーザーが作成した解答プログラムがエラー落ちした場合に標準出力・標準エラー出力がファイル出力されていなかったため、エラー落ちした場合もファイル出力されるように修正した。