### PR TITLE
順位スコアに対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -47,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -62,44 +56,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -109,21 +103,15 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -133,26 +121,26 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -163,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -173,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -185,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -197,21 +185,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys",
 ]
@@ -230,9 +218,15 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -242,27 +236,36 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -278,14 +281,15 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -301,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -311,21 +315,21 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -333,21 +337,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -422,9 +426,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pahcer"
@@ -470,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -480,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -518,18 +528,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -542,9 +552,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -562,18 +572,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -583,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -594,36 +604,40 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "ryu"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -632,23 +646,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -665,9 +680,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -702,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing_table"
@@ -727,54 +742,54 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -793,45 +808,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -839,145 +841,134 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "pahcer"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -211,6 +228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fragile"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,14 +283,25 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -304,13 +347,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -334,6 +385,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -361,9 +418,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -375,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -470,15 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +550,16 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -546,38 +604,26 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -613,6 +659,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -742,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -752,14 +804,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -770,7 +822,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -790,6 +842,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -812,6 +870,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -859,6 +926,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -931,12 +1032,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -946,25 +1041,87 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pahcer"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["terry_u16"]
 description = "A tool to run tests for AtCoder Heuristic Contest (AHC)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ clap = { version = "4.5.41", features = ["derive"] }
 colored = "3.0.0"
 num-format = "0.4.4"
 num_cpus = "1.17.0"
-rand = "0.9.2"
+rand = "0.10.1"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 tabled = { version = "0.20.0", features = ["ansi"] }
 threadpool = "1.8.1"
-toml = "0.9.2"
+toml = "1.1.2"
 
 [dev-dependencies]
-mockall = "0.13.1"
+mockall = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ $ pahcer run
 - `./pahcer/summary.md` : 実行結果のサマリが表形式で記録されたファイルです。
 - `./pahcer/best_scores.json` : ローカルでのベストスコアが保存されたJSONファイルです。
 - `./pahcer/json/result_*.json` : 実行結果の詳細が記録されたJSONファイルです。
+  - ver 0.4.0 で `--rank` 機能が追加されましたが、既存ユーザーとの互換性のため、JSON内の `relative_score` / `total_relative_score` というフィールド名は `--rank` 使用時もそのまま維持されます。
 
 デフォルトでは、 seed=0 から seed=99 までの100ケースが実行されます。カスタマイズしたい場合やうまく動かない場合は `./pahcer_config.toml` を編集してください。
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ $ pahcer run
   - `Score` : 実スコア（正の整数値のみ許容）です。0点の場合はWA扱いとなります。
   - `Relative` : ローカルでのベストスコアを100としたときの相対スコアです。
     - `OBJECTIVE = max` のときは `100 * YOURS / BEST` 、 `OBJECTIVE = min` のときは `100 * BEST / YOURS` で計算されます。
+    - `pahcer run --rank` のときは、この列は `Rank` に変わり、ローカルに保存された過去結果に対する順位スコアが表示されます。
 - `Average Score` : その時点までの平均スコアです。
   - `Score` : 実スコアの平均値です。
   - `Relative` : 相対スコアの平均値です。
+    - `pahcer run --rank` のときは、この列は `Rank` に変わり、順位スコアの平均値が表示されます。
 - `Exec. Time` : 実行時間（ミリ秒表示）です。並列実行数などにより変化しうるので参考程度にご覧ください。
 
 このとき、並列実行を行っている都合上seedの順番が実行ごとに変化することに注意してください。途中で実行を中断する場合は `Ctrl+C` を押してください。
@@ -196,6 +198,7 @@ $ pahcer run
 - `Average Score` : 実スコアの平均値です。
 - `Average Score (log10)` : 実スコアの対数を取った値の平均値です。相対スコア問題の評価などに活用いただけます。
 - `Average Relative Score` : 相対スコアの平均値です。
+  - `pahcer run --rank` のときは `Average Rank Score` が表示されます。
 - `Accepted` : Acceptされたケース数です。正の点数を取ったテストケースがAcceptedと見なされます。実行時間が長くてもTLE扱いにはなりませんのでご注意ください。
 - `Max Execution Time` : 実行時間の最大値です。
 
@@ -224,6 +227,9 @@ $ pahcer list -n 5
 
 # 全ての結果を表示
 $ pahcer list -a
+
+# 順位スコアで表示
+$ pahcer list --rank
 ```
 
 ### 5. Optunaとの連携によるパラメータ最適化（オプション）
@@ -306,6 +312,9 @@ $ pahcer run [OPTIONS]
   - 全ケース完了後に実行結果のファイル出力を行わないようにします。
 - `--no-compile`
   - 起動時にコンパイル処理を行わないようにします。
+- `--rank`
+  - 相対スコアの代わりに順位スコアを計算して表示します。
+  - 順位スコアはローカルに保存された `./pahcer/json/result_*.json` を履歴として計算されます。
 
 以下でヘルプが出せます。
 
@@ -317,6 +326,8 @@ $ pahcer init -h
 
 ```sh
 $ pahcer run -c 焼きなまし高速化バージョン -j --shuffle --setting-file settings.toml --freeze-best-scores --no-result-file
+
+$ pahcer run --rank
 ```
 
 ### `pahcer list`
@@ -333,6 +344,7 @@ $ pahcer list [OPTIONS]
 - `AC/All` : Accept数/全テストケース数
 - `Avg Score` : 平均スコア
 - `Avg Rel.` : 平均相対スコア（最新のベストスコアを元に再計算されます）
+  - `--rank` を付けた場合は `Avg Rank` に変わり、ローカルに保存された結果同士の順位スコアが表示されます。
 - `Max Time` : 最大実行時間
 - `Tag` : Gitタグ名（`pahcer/`プレフィックスは除去して表示）
 - `Comment` : テスト実行時のコメント
@@ -345,6 +357,9 @@ $ pahcer list [OPTIONS]
   - 全ての結果を表示します。
 - `--setting-file`
   - 読み込む設定ファイル（ `./pahcer_config.toml` ）のパスをデフォルトから変更します。
+- `--rank`
+  - 相対スコアの代わりに順位スコアで再計算して表示します。
+  - 順位スコアはローカルに保存された `./pahcer/json/result_*.json` 同士を比較して計算されます。
 
 以下でヘルプが出せます。
 
@@ -357,6 +372,9 @@ $ pahcer list -h
 ```sh
 # 最新10件の結果を表示
 $ pahcer list
+
+# 順位スコアで表示
+$ pahcer list --rank
 
 # 最新5件の結果を表示
 $ pahcer list -n 5

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -103,12 +103,7 @@ pub(crate) fn run(args: RunArgs) -> Result<()> {
     }
 
     let mut runner = if args.json {
-        multi::MultiCaseRunner::new_json(
-            single_runner,
-            test_cases,
-            settings.test.threads,
-            if args.rank { "Rank" } else { "Relative" },
-        )
+        multi::MultiCaseRunner::new_json(single_runner, test_cases, settings.test.threads)
     } else {
         multi::MultiCaseRunner::new_console(
             single_runner,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,3 +1,4 @@
+mod comparative_score;
 pub(crate) mod compilie;
 mod io;
 mod list;
@@ -10,6 +11,7 @@ use crate::{
 };
 use anyhow::{ensure, Context, Result};
 use clap::Args;
+use comparative_score::create_relative_score_calculator;
 use compilie::compile;
 use rand::prelude::*;
 use regex::Regex;
@@ -65,6 +67,7 @@ pub(crate) fn run(args: RunArgs) -> Result<()> {
     let single_runner = single::SingleCaseRunner::new(
         settings.test.test_steps.clone(),
         Regex::new(&settings.problem.score_regex)?,
+        create_relative_score_calculator(best_scores.clone(), settings.problem.objective),
     );
 
     let seed_range = settings.test.start_seed..settings.test.end_seed;
@@ -143,13 +146,17 @@ struct Number {
 pub(crate) fn list(args: ListArgs) -> Result<()> {
     let settings = io::load_setting_file(&args.setting_file)
         .with_context(|| format!("Failed to load the setting file {}.", &args.setting_file))?;
+    let best_score_path = io::get_best_score_path(&settings.test.out_dir);
+    let best_scores = io::load_best_scores(&best_score_path)?;
+    let relative_score_calculator =
+        create_relative_score_calculator(best_scores, settings.problem.objective);
 
     let limit = if args.number.all {
         None
     } else {
         Some(args.number.number)
     };
-    list::list_past_results(&settings, limit)?;
+    list::list_past_results(&settings, limit, relative_score_calculator.as_ref())?;
 
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -169,12 +169,12 @@ struct Number {
 pub(crate) fn list(args: ListArgs) -> Result<()> {
     let settings = io::load_setting_file(&args.setting_file)
         .with_context(|| format!("Failed to load the setting file {}.", &args.setting_file))?;
-    let best_score_path = io::get_best_score_path(&settings.test.out_dir);
-    let best_scores = io::load_best_scores(&best_score_path)?;
     let score_calculator = if args.rank {
         let all_results = io::load_result_jsons(&settings.test.out_dir, None)?;
         create_rank_score_calculator(&all_results, settings.problem.objective, true)
     } else {
+        let best_score_path = io::get_best_score_path(&settings.test.out_dir);
+        let best_scores = io::load_best_scores(&best_score_path)?;
         create_relative_score_calculator(best_scores, settings.problem.objective)
     };
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -183,7 +183,12 @@ pub(crate) fn list(args: ListArgs) -> Result<()> {
     } else {
         Some(args.number.number)
     };
-    list::list_past_results(&settings, limit, score_calculator.as_ref())?;
+    list::list_past_results(
+        &settings,
+        limit,
+        score_calculator.as_ref(),
+        if args.rank { "Rank" } else { "Rel." },
+    )?;
 
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::{ensure, Context, Result};
 use clap::Args;
-use comparative_score::create_relative_score_calculator;
+use comparative_score::{create_rank_score_calculator, create_relative_score_calculator};
 use compilie::compile;
 use rand::prelude::*;
 use regex::Regex;
@@ -42,6 +42,9 @@ pub(crate) struct RunArgs {
     /// Do not compile the code
     #[clap(long = "no-compile")]
     no_compile: bool,
+    /// Use rank score instead of relative score
+    #[clap(long = "rank")]
+    rank: bool,
 }
 
 pub(crate) fn run(args: RunArgs) -> Result<()> {
@@ -64,10 +67,17 @@ pub(crate) fn run(args: RunArgs) -> Result<()> {
         None => None,
     };
 
+    let score_calculator = if args.rank {
+        let past_results = io::load_result_jsons(&settings.test.out_dir, None)?;
+        create_rank_score_calculator(&past_results, settings.problem.objective, false)
+    } else {
+        create_relative_score_calculator(best_scores.clone(), settings.problem.objective)
+    };
+
     let single_runner = single::SingleCaseRunner::new(
         settings.test.test_steps.clone(),
         Regex::new(&settings.problem.score_regex)?,
-        create_relative_score_calculator(best_scores.clone(), settings.problem.objective),
+        score_calculator,
     );
 
     let seed_range = settings.test.start_seed..settings.test.end_seed;
@@ -93,9 +103,19 @@ pub(crate) fn run(args: RunArgs) -> Result<()> {
     }
 
     let mut runner = if args.json {
-        multi::MultiCaseRunner::new_json(single_runner, test_cases, settings.test.threads)
+        multi::MultiCaseRunner::new_json(
+            single_runner,
+            test_cases,
+            settings.test.threads,
+            if args.rank { "Rank" } else { "Relative" },
+        )
     } else {
-        multi::MultiCaseRunner::new_console(single_runner, test_cases, settings.test.threads)
+        multi::MultiCaseRunner::new_console(
+            single_runner,
+            test_cases,
+            settings.test.threads,
+            if args.rank { "Rank" } else { "Relative" },
+        )
     };
     let stats = runner.run()?;
 
@@ -130,6 +150,9 @@ pub(crate) struct ListArgs {
     /// Path to the setting file
     #[clap(long = "setting-file", default_value = SETTING_FILE_PATH)]
     setting_file: String,
+    /// Use rank score instead of relative score
+    #[clap(long = "rank")]
+    rank: bool,
 }
 
 #[derive(Debug, Clone, Copy, Args)]
@@ -148,15 +171,19 @@ pub(crate) fn list(args: ListArgs) -> Result<()> {
         .with_context(|| format!("Failed to load the setting file {}.", &args.setting_file))?;
     let best_score_path = io::get_best_score_path(&settings.test.out_dir);
     let best_scores = io::load_best_scores(&best_score_path)?;
-    let relative_score_calculator =
-        create_relative_score_calculator(best_scores, settings.problem.objective);
+    let score_calculator = if args.rank {
+        let all_results = io::load_result_jsons(&settings.test.out_dir, None)?;
+        create_rank_score_calculator(&all_results, settings.problem.objective, true)
+    } else {
+        create_relative_score_calculator(best_scores, settings.problem.objective)
+    };
 
     let limit = if args.number.all {
         None
     } else {
         Some(args.number.number)
     };
-    list::list_past_results(&settings, limit, relative_score_calculator.as_ref())?;
+    list::list_past_results(&settings, limit, score_calculator.as_ref())?;
 
     Ok(())
 }

--- a/src/runner/comparative_score.rs
+++ b/src/runner/comparative_score.rs
@@ -1,5 +1,7 @@
-use super::single::Objective;
+use super::{io::AllResultJson, single::Objective};
 use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
+
+const PERFECT_RANK_SCORE: f64 = 100.0;
 
 /// ケースごとの比較スコアを計算する抽象インターフェース。
 ///
@@ -29,14 +31,6 @@ impl RelativeScoreCalculator {
     }
 }
 
-/// 相対スコア計算器を共有可能な `Arc` に包んで生成する。
-pub(super) fn create_relative_score_calculator(
-    best_scores: HashMap<u64, NonZeroU64>,
-    objective: Objective,
-) -> Arc<dyn ComparativeScoreCalculator> {
-    Arc::new(RelativeScoreCalculator::new(best_scores, objective))
-}
-
 impl ComparativeScoreCalculator for RelativeScoreCalculator {
     fn calculate(&self, seed: u64, score: NonZeroU64) -> f64 {
         match (self.best_scores.get(&seed).copied(), self.objective) {
@@ -49,6 +43,105 @@ impl ComparativeScoreCalculator for RelativeScoreCalculator {
             (None, _) => 100.0,
         }
     }
+}
+
+/// 相対スコア計算器を共有可能な `Arc` に包んで生成する。
+pub(super) fn create_relative_score_calculator(
+    best_scores: HashMap<u64, NonZeroU64>,
+    objective: Objective,
+) -> Arc<dyn ComparativeScoreCalculator> {
+    Arc::new(RelativeScoreCalculator::new(best_scores, objective))
+}
+
+/// ローカルに保存された提出結果に対する順位スコアを計算する実装。
+pub(super) struct RankScoreCalculator {
+    scores_by_seed: HashMap<u64, Vec<NonZeroU64>>,
+    objective: Objective,
+    includes_current_submission: bool,
+}
+
+impl RankScoreCalculator {
+    /// 過去の結果一覧から順位スコア計算器を構築する。
+    pub(super) fn new(
+        results: &[AllResultJson],
+        objective: Objective,
+        includes_current_submission: bool,
+    ) -> Self {
+        let mut scores_by_seed = HashMap::<u64, Vec<NonZeroU64>>::new();
+
+        for result in results {
+            for case in &result.cases {
+                let Some(score) = NonZeroU64::new(case.score) else {
+                    continue;
+                };
+                scores_by_seed.entry(case.seed).or_default().push(score);
+            }
+        }
+
+        for scores in scores_by_seed.values_mut() {
+            scores.sort_unstable();
+        }
+
+        Self {
+            scores_by_seed,
+            objective,
+            includes_current_submission,
+        }
+    }
+}
+
+impl ComparativeScoreCalculator for RankScoreCalculator {
+    fn calculate(&self, seed: u64, score: NonZeroU64) -> f64 {
+        let scores = self.scores_by_seed.get(&seed);
+        let history_count = scores.map_or(0, Vec::len);
+        let n_submit = history_count + usize::from(!self.includes_current_submission);
+
+        if n_submit == 0 {
+            return PERFECT_RANK_SCORE;
+        }
+
+        let (better_count, equal_count) = scores
+            .map(|scores| count_better_and_equal_scores(scores, score, self.objective))
+            .unwrap_or((0, 0));
+
+        let tie_count = if self.includes_current_submission {
+            equal_count.saturating_sub(1)
+        } else {
+            equal_count
+        };
+        let rank = better_count as f64 + 0.5 * tie_count as f64;
+
+        let score = PERFECT_RANK_SCORE * (1.0 - rank / n_submit as f64);
+        score.max(0.0)
+    }
+}
+
+fn count_better_and_equal_scores(
+    scores: &[NonZeroU64],
+    target: NonZeroU64,
+    objective: Objective,
+) -> (usize, usize) {
+    let lower_bound = scores.partition_point(|score| score < &target);
+    let upper_bound = scores.partition_point(|score| score <= &target);
+    let equal_count = upper_bound - lower_bound;
+
+    match objective {
+        Objective::Max => (scores.len() - upper_bound, equal_count),
+        Objective::Min => (lower_bound, equal_count),
+    }
+}
+
+/// 順位スコア計算器を共有可能な `Arc` に包んで生成する。
+pub(super) fn create_rank_score_calculator(
+    results: &[AllResultJson],
+    objective: Objective,
+    includes_current_submission: bool,
+) -> Arc<dyn ComparativeScoreCalculator> {
+    Arc::new(RankScoreCalculator::new(
+        results,
+        objective,
+        includes_current_submission,
+    ))
 }
 
 #[cfg(test)]
@@ -113,5 +206,96 @@ mod test {
             / scores.len() as f64;
 
         assert_eq!(average, 100.0);
+    }
+
+    #[test]
+    fn test_rank_score_without_history() {
+        let calculator = RankScoreCalculator::new(&[], Objective::Min, false);
+
+        assert_eq!(
+            calculator.calculate(42, NonZeroU64::new(200).unwrap()),
+            100.0
+        );
+    }
+
+    #[test]
+    fn test_rank_score_for_new_submission() {
+        let results = [AllResultJson {
+            start_time: chrono::Local::now(),
+            case_count: 1,
+            total_score: 100,
+            total_score_log10: 2.0,
+            total_relative_score: 100.0,
+            max_execution_time: 0.1,
+            comment: String::new(),
+            tag_name: None,
+            wa_seeds: vec![],
+            cases: vec![
+                super::super::io::CaseResultJson {
+                    seed: 0,
+                    score: 100,
+                    relative_score: 100.0,
+                    execution_time: 0.1,
+                    error_message: String::new(),
+                },
+                super::super::io::CaseResultJson {
+                    seed: 0,
+                    score: 200,
+                    relative_score: 50.0,
+                    execution_time: 0.1,
+                    error_message: String::new(),
+                },
+            ],
+        }];
+        let calculator = RankScoreCalculator::new(&results, Objective::Min, false);
+
+        assert_eq!(
+            calculator.calculate(0, NonZeroU64::new(150).unwrap()),
+            66.66666666666667
+        );
+    }
+
+    #[test]
+    fn test_rank_score_for_saved_submission() {
+        let results = [AllResultJson {
+            start_time: chrono::Local::now(),
+            case_count: 1,
+            total_score: 100,
+            total_score_log10: 2.0,
+            total_relative_score: 100.0,
+            max_execution_time: 0.1,
+            comment: String::new(),
+            tag_name: None,
+            wa_seeds: vec![],
+            cases: vec![
+                super::super::io::CaseResultJson {
+                    seed: 0,
+                    score: 100,
+                    relative_score: 100.0,
+                    execution_time: 0.1,
+                    error_message: String::new(),
+                },
+                super::super::io::CaseResultJson {
+                    seed: 0,
+                    score: 100,
+                    relative_score: 100.0,
+                    execution_time: 0.1,
+                    error_message: String::new(),
+                },
+                super::super::io::CaseResultJson {
+                    seed: 0,
+                    score: 200,
+                    relative_score: 50.0,
+                    execution_time: 0.1,
+                    error_message: String::new(),
+                },
+            ],
+        }];
+        let calculator = RankScoreCalculator::new(&results, Objective::Min, true);
+
+        assert_eq!(
+            calculator.calculate(0, NonZeroU64::new(100).unwrap()),
+            83.33333333333334
+        );
     }
 }

--- a/src/runner/comparative_score.rs
+++ b/src/runner/comparative_score.rs
@@ -222,7 +222,7 @@ mod test {
     fn test_rank_score_for_new_submission() {
         let results = [AllResultJson {
             start_time: chrono::Local::now(),
-            case_count: 1,
+            case_count: 2,
             total_score: 100,
             total_score_log10: 2.0,
             total_relative_score: 100.0,
@@ -259,7 +259,7 @@ mod test {
     fn test_rank_score_for_saved_submission() {
         let results = [AllResultJson {
             start_time: chrono::Local::now(),
-            case_count: 1,
+            case_count: 3,
             total_score: 100,
             total_score_log10: 2.0,
             total_relative_score: 100.0,

--- a/src/runner/comparative_score.rs
+++ b/src/runner/comparative_score.rs
@@ -1,0 +1,117 @@
+use super::single::Objective;
+use std::{collections::HashMap, num::NonZeroU64, sync::Arc};
+
+/// ケースごとの比較スコアを計算する抽象インターフェース。
+///
+/// `seed` とそのケースで得られた `score` を受け取り、表示・集計に使う比較スコアを返す。
+/// 具体的な計算内容は、相対スコア・順位スコアなど問題ごとの実装に委ねる。
+pub(super) trait ComparativeScoreCalculator: Send + Sync {
+    /// 指定したケースの比較スコアを計算する。
+    fn calculate(&self, seed: u64, score: NonZeroU64) -> f64;
+}
+
+/// 既知のベストスコアに対する相対スコアを計算する実装。
+///
+/// `Objective::Max` では `score / best_score * 100`、
+/// `Objective::Min` では `best_score / score * 100` を返す。
+pub(super) struct RelativeScoreCalculator {
+    best_scores: HashMap<u64, NonZeroU64>,
+    objective: Objective,
+}
+
+impl RelativeScoreCalculator {
+    /// ベストスコア表と最適化方向から相対スコア計算器を構築する。
+    pub(super) fn new(best_scores: HashMap<u64, NonZeroU64>, objective: Objective) -> Self {
+        Self {
+            best_scores,
+            objective,
+        }
+    }
+}
+
+/// 相対スコア計算器を共有可能な `Arc` に包んで生成する。
+pub(super) fn create_relative_score_calculator(
+    best_scores: HashMap<u64, NonZeroU64>,
+    objective: Objective,
+) -> Arc<dyn ComparativeScoreCalculator> {
+    Arc::new(RelativeScoreCalculator::new(best_scores, objective))
+}
+
+impl ComparativeScoreCalculator for RelativeScoreCalculator {
+    fn calculate(&self, seed: u64, score: NonZeroU64) -> f64 {
+        match (self.best_scores.get(&seed).copied(), self.objective) {
+            (Some(reference_score), Objective::Max) => {
+                score.get() as f64 / reference_score.get() as f64 * 100.0
+            }
+            (Some(reference_score), Objective::Min) => {
+                reference_score.get() as f64 / score.get() as f64 * 100.0
+            }
+            (None, _) => 100.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_relative_score_max() {
+        let best_scores = HashMap::from([(42, NonZeroU64::new(100).unwrap())]);
+        let calculator = RelativeScoreCalculator::new(best_scores, Objective::Max);
+
+        assert_eq!(
+            calculator.calculate(42, NonZeroU64::new(200).unwrap()),
+            200.0
+        );
+    }
+
+    #[test]
+    fn test_relative_score_min() {
+        let best_scores = HashMap::from([(42, NonZeroU64::new(100).unwrap())]);
+        let calculator = RelativeScoreCalculator::new(best_scores, Objective::Min);
+
+        assert_eq!(
+            calculator.calculate(42, NonZeroU64::new(200).unwrap()),
+            50.0
+        );
+    }
+
+    #[test]
+    fn test_relative_score_without_reference() {
+        let best_scores = HashMap::new();
+        let calculator = RelativeScoreCalculator::new(best_scores, Objective::Max);
+
+        assert_eq!(
+            calculator.calculate(42, NonZeroU64::new(200).unwrap()),
+            100.0
+        );
+    }
+
+    #[test]
+    fn test_average_relative_score_with_failed_case() {
+        let best_scores = HashMap::from([
+            (0, NonZeroU64::new(100).unwrap()),
+            (1, NonZeroU64::new(100).unwrap()),
+            (2, NonZeroU64::new(100).unwrap()),
+        ]);
+        let calculator = RelativeScoreCalculator::new(best_scores, Objective::Max);
+        let scores = [
+            (0, NonZeroU64::new(100)),
+            (1, NonZeroU64::new(200)),
+            (2, None),
+        ];
+
+        let average = scores
+            .into_iter()
+            .map(|(seed, score)| {
+                score
+                    .map(|score| calculator.calculate(seed, score))
+                    .unwrap_or(0.0)
+            })
+            .sum::<f64>()
+            / scores.len() as f64;
+
+        assert_eq!(average, 100.0);
+    }
+}

--- a/src/runner/io.rs
+++ b/src/runner/io.rs
@@ -295,11 +295,13 @@ mod test {
                 TestResult::new(
                     TestCase::new(0, None, Objective::Max),
                     Ok(NonZero::new(1000).unwrap()),
+                    Ok(100.0),
                     Duration::from_millis(1000),
                 ),
                 TestResult::new(
                     TestCase::new(1, None, Objective::Max),
                     Ok(NonZero::new(10000).unwrap()),
+                    Ok(100.0),
                     Duration::from_millis(100),
                 ),
             ],

--- a/src/runner/io.rs
+++ b/src/runner/io.rs
@@ -225,7 +225,7 @@ impl AllResultJson {
                 CaseResultJson::new(
                     r.test_case().seed(),
                     score,
-                    *r.relative_score().as_ref().unwrap_or(&0.0),
+                    *r.comparative_score().as_ref().unwrap_or(&0.0),
                     r.execution_time().as_secs_f64(),
                     error_message,
                 )
@@ -247,7 +247,7 @@ impl AllResultJson {
             case_count: stats.results.len(),
             total_score: stats.score_sum,
             total_score_log10: stats.score_sum_log10,
-            total_relative_score: stats.relative_score_sum,
+            total_relative_score: stats.comparative_score_sum,
             max_execution_time,
             comment: comment.to_string(),
             wa_seeds,

--- a/src/runner/io.rs
+++ b/src/runner/io.rs
@@ -53,6 +53,53 @@ pub(super) fn load_best_scores(path: impl AsRef<Path>) -> Result<HashMap<u64, No
     Ok(map)
 }
 
+pub(super) fn load_result_jsons(
+    dir_path: impl AsRef<OsStr>,
+    limit: Option<usize>,
+) -> Result<Vec<AllResultJson>> {
+    let json_dir = get_json_dir_path(dir_path);
+
+    if !json_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut json_files = vec![];
+
+    for entry in std::fs::read_dir(&json_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+            if file_name.starts_with("result_") && file_name.ends_with(".json") {
+                json_files.push(path);
+            }
+        }
+    }
+
+    json_files.sort_by(|a, b| {
+        let name_a = a.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let name_b = b.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        name_b.cmp(name_a)
+    });
+
+    if let Some(limit_value) = limit {
+        json_files.truncate(limit_value);
+    }
+
+    let results = json_files
+        .iter()
+        .filter_map(|file| match load_result_json(file) {
+            Ok(result) => Some(result),
+            Err(e) => {
+                eprintln!("Failed to load JSON file {}: {}", file.display(), e);
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(results)
+}
+
 pub(super) fn save_best_scores(
     path: impl AsRef<Path>,
     best_scores: HashMap<u64, NonZeroU64>,

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -1,10 +1,10 @@
+use super::comparative_score::ComparativeScoreCalculator;
 use super::io::{load_result_json, AllResultJson};
 use crate::runner::io;
 use crate::runner::single::Objective;
 use crate::settings::Settings;
 use anyhow::{ensure, Result};
 use colored::Colorize as _;
-use std::collections::HashMap;
 use std::fs;
 use std::num::NonZeroU64;
 use tabled::{
@@ -31,7 +31,11 @@ struct ResultTableRow {
 }
 
 /// 過去のテスト結果をリスト表示する関数
-pub(super) fn list_past_results(settings: &Settings, limit: Option<usize>) -> Result<()> {
+pub(super) fn list_past_results(
+    settings: &Settings,
+    limit: Option<usize>,
+    score_calculator: &dyn ComparativeScoreCalculator,
+) -> Result<()> {
     // JSONファイルから結果を読み込む
     let results = load_results(settings, limit)?;
 
@@ -39,17 +43,15 @@ pub(super) fn list_past_results(settings: &Settings, limit: Option<usize>) -> Re
     let best_avg_absolute_score = calculate_best_avg_absolute_score(settings, &results);
 
     // 相対ベストスコア
-    let best_scores = load_best_scores(settings);
-    let best_avg_relative_score =
-        calculate_best_avg_relative_score(settings, &results, &best_scores);
+    let best_avg_comparative_score =
+        calculate_best_avg_comparative_score(&results, score_calculator);
 
     // テーブル形式で結果を表示
     print_table(
-        settings,
         results,
+        score_calculator,
+        best_avg_comparative_score,
         best_avg_absolute_score,
-        best_scores,
-        best_avg_relative_score,
     );
 
     Ok(())
@@ -123,59 +125,43 @@ fn calculate_best_avg_absolute_score(settings: &Settings, results: &[AllResultJs
     best_avg_absolute_score
 }
 
-fn load_best_scores(settings: &Settings) -> HashMap<u64, NonZeroU64> {
-    let best_score_path = io::get_best_score_path(&settings.test.out_dir);
-    io::load_best_scores(&best_score_path).unwrap_or_else(|_| std::collections::HashMap::new())
-}
-
-fn calculate_best_avg_relative_score(
-    settings: &Settings,
+fn calculate_best_avg_comparative_score(
     results: &[AllResultJson],
-    best_scores: &HashMap<u64, NonZeroU64>,
+    score_calculator: &dyn ComparativeScoreCalculator,
 ) -> f64 {
-    let best_avg_relative_score = results
+    let best_avg_comparative_score = results
         .iter()
-        .map(|result| calc_average_relative_score(result, best_scores, settings.problem.objective))
+        .map(|result| calculate_average_comparative_score(result, score_calculator))
         .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or(f64::NAN);
 
-    best_avg_relative_score
+    best_avg_comparative_score
 }
 
-fn calc_average_relative_score(
+fn calculate_average_comparative_score(
     result: &AllResultJson,
-    best_scores: &HashMap<u64, NonZeroU64>,
-    objective: Objective,
+    score_calculator: &dyn ComparativeScoreCalculator,
 ) -> f64 {
     if result.case_count == 0 {
         return 0.0;
     }
 
-    let mut total_relative_score = 0.0;
+    let total_comparative_score = result
+        .cases
+        .iter()
+        .filter_map(|case| {
+            NonZeroU64::new(case.score).map(|score| score_calculator.calculate(case.seed, score))
+        })
+        .sum::<f64>();
 
-    for case in &result.cases {
-        if case.score == 0 {
-            continue; // スコアが0のケースは無視
-        }
-
-        let relative_score = match (best_scores.get(&case.seed).copied(), objective) {
-            (Some(best), Objective::Max) => case.score as f64 / best.get() as f64 * 100.0,
-            (Some(best), Objective::Min) => best.get() as f64 / case.score as f64 * 100.0,
-            (None, _) => 100.0,
-        };
-
-        total_relative_score += relative_score;
-    }
-
-    total_relative_score / result.case_count as f64
+    total_comparative_score / result.case_count as f64
 }
 
 fn print_table(
-    settings: &Settings,
     results: Vec<AllResultJson>,
+    score_calculator: &dyn ComparativeScoreCalculator,
+    best_avg_comparative_score: f64,
     best_avg_absolute_score: f64,
-    best_scores: HashMap<u64, NonZeroU64>,
-    best_avg_relative_score: f64,
 ) {
     // 結果を読み込んで表示
     let mut table_rows = vec![];
@@ -183,10 +169,9 @@ fn print_table(
     for result in results {
         table_rows.push(convert_to_table_row(
             result,
-            &best_scores,
-            settings.problem.objective,
+            score_calculator,
             best_avg_absolute_score,
-            best_avg_relative_score,
+            best_avg_comparative_score,
         ));
     }
 
@@ -199,10 +184,9 @@ fn print_table(
 
 fn convert_to_table_row(
     result: AllResultJson,
-    best_scores: &HashMap<u64, NonZeroU64>,
-    objective: Objective,
+    score_calculator: &dyn ComparativeScoreCalculator,
     best_avg_absolute_score: f64,
-    best_avg_relative_score: f64,
+    best_avg_comparative_score: f64,
 ) -> ResultTableRow {
     let time_str = result.start_time.format("%m/%d %H:%M:%S").to_string();
     let ac_count = result.case_count - result.wa_seeds.len();
@@ -224,9 +208,9 @@ fn convert_to_table_row(
     } else {
         avg_score
     };
-    let avg_relative_f64 = calc_average_relative_score(&result, best_scores, objective);
-    let avg_relative = format!("{avg_relative_f64:.3}");
-    let avg_relative = if avg_relative_f64 == best_avg_relative_score {
+    let avg_comparative_score = calculate_average_comparative_score(&result, score_calculator);
+    let avg_relative = format!("{avg_comparative_score:.3}");
+    let avg_relative = if avg_comparative_score == best_avg_comparative_score {
         avg_relative.bold().green().to_string()
     } else {
         avg_relative

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -108,7 +108,11 @@ fn calculate_average_comparative_score(
 
 fn normalize_zero(value: f64) -> f64 {
     // 表示時に `-0.000` になるのを避けるため、符号付きゼロを正規化する。
-    if value == 0.0 { 0.0 } else { value }
+    if value == 0.0 {
+        0.0
+    } else {
+        value
+    }
 }
 
 fn print_table(

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -32,7 +32,7 @@ pub(super) fn list_past_results(
     let results = io::load_result_jsons(&settings.test.out_dir, limit)?;
     ensure!(
         !results.is_empty(),
-        "No results found. JSON directory does not exist or contains no result files: {}",
+        "No results found. JSON directory may not exist, may contain no result files, or all result files may have failed to load: {}",
         io::get_json_dir_path(&settings.test.out_dir).display()
     );
 

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -7,25 +7,18 @@ use anyhow::{ensure, Result};
 use colored::Colorize as _;
 use std::num::NonZeroU64;
 use tabled::{
+    builder::Builder,
     settings::{object::Columns, Alignment, Style},
-    Table, Tabled,
+    Table,
 };
 
-#[derive(Tabled)]
 struct ResultTableRow {
-    #[tabled(rename = "Time")]
     time: String,
-    #[tabled(rename = "AC/All")]
     ac_total: String,
-    #[tabled(rename = "Avg Score")]
     avg_score: String,
-    #[tabled(rename = "Avg Rel.")]
     avg_relative: String,
-    #[tabled(rename = "Max Time")]
     max_time: String,
-    #[tabled(rename = "Tag")]
     tag: String,
-    #[tabled(rename = "Comment")]
     comment: String,
 }
 
@@ -34,6 +27,7 @@ pub(super) fn list_past_results(
     settings: &Settings,
     limit: Option<usize>,
     score_calculator: &dyn ComparativeScoreCalculator,
+    comparative_label: &'static str,
 ) -> Result<()> {
     // JSONファイルから結果を読み込む
     let results = io::load_result_jsons(&settings.test.out_dir, limit)?;
@@ -56,6 +50,7 @@ pub(super) fn list_past_results(
         score_calculator,
         best_avg_comparative_score,
         best_avg_absolute_score,
+        comparative_label,
     );
 
     Ok(())
@@ -117,6 +112,7 @@ fn print_table(
     score_calculator: &dyn ComparativeScoreCalculator,
     best_avg_comparative_score: f64,
     best_avg_absolute_score: f64,
+    comparative_label: &'static str,
 ) {
     // 結果を読み込んで表示
     let mut table_rows = vec![];
@@ -131,7 +127,29 @@ fn print_table(
     }
 
     // tabledを使ってテーブルを表示
-    let mut table = Table::new(table_rows);
+    let mut builder = Builder::default();
+    builder.push_record([
+        "Time",
+        "AC/All",
+        "Avg Score",
+        &format!("Avg {comparative_label}"),
+        "Max Time",
+        "Tag",
+        "Comment",
+    ]);
+    for row in table_rows {
+        builder.push_record([
+            row.time,
+            row.ac_total,
+            row.avg_score,
+            row.avg_relative,
+            row.max_time,
+            row.tag,
+            row.comment,
+        ]);
+    }
+
+    let mut table = Table::from(builder.build());
     table.with(Style::markdown());
     table.modify(Columns::new(1..=4), Alignment::right());
     println!("{table}");

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -9,7 +9,6 @@ use std::num::NonZeroU64;
 use tabled::{
     builder::Builder,
     settings::{object::Columns, Alignment, Style},
-    Table,
 };
 
 struct ResultTableRow {
@@ -157,7 +156,7 @@ fn print_table(
         ]);
     }
 
-    let mut table = Table::from(builder.build());
+    let mut table = builder.build();
     table.with(Style::markdown());
     table.modify(Columns::new(1..=4), Alignment::right());
     println!("{table}");

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -103,8 +103,12 @@ fn calculate_average_comparative_score(
             NonZeroU64::new(case.score).map(|score| score_calculator.calculate(case.seed, score))
         })
         .sum::<f64>();
+    normalize_zero(total_comparative_score / result.case_count as f64)
+}
 
-    total_comparative_score / result.case_count as f64
+fn normalize_zero(value: f64) -> f64 {
+    // 表示時に `-0.000` になるのを避けるため、符号付きゼロを正規化する。
+    if value == 0.0 { 0.0 } else { value }
 }
 
 fn print_table(

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -1,11 +1,10 @@
 use super::comparative_score::ComparativeScoreCalculator;
-use super::io::{load_result_json, AllResultJson};
+use super::io::AllResultJson;
 use crate::runner::io;
 use crate::runner::single::Objective;
 use crate::settings::Settings;
 use anyhow::{ensure, Result};
 use colored::Colorize as _;
-use std::fs;
 use std::num::NonZeroU64;
 use tabled::{
     settings::{object::Columns, Alignment, Style},
@@ -37,7 +36,12 @@ pub(super) fn list_past_results(
     score_calculator: &dyn ComparativeScoreCalculator,
 ) -> Result<()> {
     // JSONファイルから結果を読み込む
-    let results = load_results(settings, limit)?;
+    let results = io::load_result_jsons(&settings.test.out_dir, limit)?;
+    ensure!(
+        !results.is_empty(),
+        "No results found. JSON directory does not exist or contains no result files: {}",
+        io::get_json_dir_path(&settings.test.out_dir).display()
+    );
 
     // 絶対ベストスコア
     let best_avg_absolute_score = calculate_best_avg_absolute_score(settings, &results);
@@ -55,55 +59,6 @@ pub(super) fn list_past_results(
     );
 
     Ok(())
-}
-
-fn load_results(settings: &Settings, limit: Option<usize>) -> Result<Vec<AllResultJson>> {
-    let json_dir = io::get_json_dir_path(&settings.test.out_dir);
-
-    ensure!(
-        json_dir.exists(),
-        "No results found. JSON directory does not exist: {}",
-        json_dir.display()
-    );
-
-    let mut json_files = vec![];
-
-    for entry in fs::read_dir(&json_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-
-        if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-            if file_name.starts_with("result_") && file_name.ends_with(".json") {
-                json_files.push(path);
-            }
-        }
-    }
-
-    // ファイル名でソート（新しい順）
-    json_files.sort_by(|a, b| {
-        let name_a = a.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        let name_b = b.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        name_b.cmp(name_a)
-    });
-
-    // 制限数まで読み込み（Noneの場合は制限なし）
-    if let Some(limit_value) = limit {
-        json_files.truncate(limit_value);
-    }
-
-    // ファイルを読み込み
-    let results = json_files
-        .iter()
-        .filter_map(|file| match load_result_json(file) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                eprintln!("Failed to load JSON file {}: {}", file.display(), e);
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-
-    Ok(results)
 }
 
 fn calculate_best_avg_absolute_score(settings: &Settings, results: &[AllResultJson]) -> f64 {

--- a/src/runner/list.rs
+++ b/src/runner/list.rs
@@ -15,7 +15,7 @@ struct ResultTableRow {
     time: String,
     ac_total: String,
     avg_score: String,
-    avg_relative: String,
+    avg_comparative: String,
     max_time: String,
     tag: String,
     comment: String,
@@ -149,7 +149,7 @@ fn print_table(
             row.time,
             row.ac_total,
             row.avg_score,
-            row.avg_relative,
+            row.avg_comparative,
             row.max_time,
             row.tag,
             row.comment,
@@ -189,11 +189,11 @@ fn convert_to_table_row(
         avg_score
     };
     let avg_comparative_score = calculate_average_comparative_score(&result, score_calculator);
-    let avg_relative = format!("{avg_comparative_score:.3}");
-    let avg_relative = if avg_comparative_score == best_avg_comparative_score {
-        avg_relative.bold().green().to_string()
+    let avg_comparative = format!("{avg_comparative_score:.3}");
+    let avg_comparative = if avg_comparative_score == best_avg_comparative_score {
+        avg_comparative.bold().green().to_string()
     } else {
-        avg_relative
+        avg_comparative
     };
 
     let max_time = format!("{:.0} ms", result.max_execution_time * 1e3);
@@ -207,7 +207,7 @@ fn convert_to_table_row(
         time: time_str,
         ac_total,
         avg_score,
-        avg_relative,
+        avg_comparative,
         max_time,
         tag: tag_display,
         comment: result.comment,

--- a/src/runner/multi.rs
+++ b/src/runner/multi.rs
@@ -140,10 +140,11 @@ impl TestStats {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runner::comparative_score::RelativeScoreCalculator;
     use crate::runner::single::{Objective, TestStep};
     use printer::MockPrinter;
     use regex::Regex;
-    use std::num::NonZero;
+    use std::{num::NonZero, sync::Arc};
 
     thread_local!(static SCORE_REGEX: Regex = Regex::new(r"^\s*Score\s*=\s*(?P<score>\d+)\s*$").unwrap());
 
@@ -158,7 +159,18 @@ mod test {
             None,
             true,
         )];
-        let single_runner = SingleCaseRunner::new(steps, SCORE_REGEX.with(|r| r.clone()));
+        let single_runner = SingleCaseRunner::new(
+            steps,
+            SCORE_REGEX.with(|r| r.clone()),
+            Arc::new(RelativeScoreCalculator::new(
+                [(0, NonZero::new(100).unwrap())]
+                    .into_iter()
+                    .chain([(1, NonZero::new(200).unwrap())])
+                    .chain([(2, NonZero::new(50).unwrap())])
+                    .collect(),
+                Objective::Max,
+            )),
+        );
         let test_cases = vec![
             TestCase::new(0, NonZero::new(100), Objective::Max),
             TestCase::new(1, NonZero::new(200), Objective::Max),

--- a/src/runner/multi.rs
+++ b/src/runner/multi.rs
@@ -33,9 +33,8 @@ impl MultiCaseRunner {
         single_runner: SingleCaseRunner,
         test_cases: Vec<TestCase>,
         threads: usize,
-        comparative_label: &'static str,
     ) -> Self {
-        let printer = Box::new(printer::JsonPrinter::new(comparative_label));
+        let printer = Box::new(printer::JsonPrinter::new());
         Self::new(single_runner, test_cases, threads, printer)
     }
 

--- a/src/runner/multi.rs
+++ b/src/runner/multi.rs
@@ -110,7 +110,7 @@ pub(super) struct TestStats {
     pub(super) results: Vec<TestResult>,
     pub(super) score_sum: u64,
     pub(super) score_sum_log10: f64,
-    pub(super) relative_score_sum: f64,
+    pub(super) comparative_score_sum: f64,
     pub(super) start_time: DateTime<Local>,
 }
 
@@ -125,9 +125,9 @@ impl TestStats {
             .filter_map(|r| r.score_log10().ok())
             .sum::<f64>()
             .max(0.0);
-        let relative_score_sum = results
+        let comparative_score_sum = results
             .iter()
-            .filter_map(|r| r.relative_score().as_ref().ok())
+            .filter_map(|r| r.comparative_score().as_ref().ok())
             .sum::<f64>()
             .max(0.0);
 
@@ -135,7 +135,7 @@ impl TestStats {
             results,
             score_sum,
             score_sum_log10,
-            relative_score_sum,
+            comparative_score_sum,
             start_time,
         }
     }
@@ -198,6 +198,6 @@ mod test {
         assert_eq!(stats.results.len(), 4);
         assert_eq!(stats.score_sum, 400);
         assert_eq!(stats.score_sum_log10, 8.0);
-        assert_eq!(stats.relative_score_sum, 450.0);
+        assert_eq!(stats.comparative_score_sum, 450.0);
     }
 }

--- a/src/runner/multi.rs
+++ b/src/runner/multi.rs
@@ -20,8 +20,12 @@ impl MultiCaseRunner {
         single_runner: SingleCaseRunner,
         test_cases: Vec<TestCase>,
         threads: usize,
+        comparative_label: &'static str,
     ) -> Self {
-        let printer = Box::new(printer::ConsolePrinter::new(test_cases.len()));
+        let printer = Box::new(printer::ConsolePrinter::new(
+            test_cases.len(),
+            comparative_label,
+        ));
         Self::new(single_runner, test_cases, threads, printer)
     }
 
@@ -29,8 +33,9 @@ impl MultiCaseRunner {
         single_runner: SingleCaseRunner,
         test_cases: Vec<TestCase>,
         threads: usize,
+        comparative_label: &'static str,
     ) -> Self {
-        let printer = Box::new(printer::JsonPrinter::new());
+        let printer = Box::new(printer::JsonPrinter::new(comparative_label));
         Self::new(single_runner, test_cases, threads, printer)
     }
 

--- a/src/runner/multi/printer.rs
+++ b/src/runner/multi/printer.rs
@@ -302,15 +302,18 @@ Max Execution Time     : 12,345 ms
             TestResult::new(
                 TestCase::new(0, NonZero::new(100), Objective::Max),
                 Ok(NonZero::new(1000).unwrap()),
+                Ok(1000.0),
                 Duration::from_millis(1234),
             ),
             TestResult::new(
                 TestCase::new(1, NonZero::new(100), Objective::Max),
                 Ok(NonZero::new(500).unwrap()),
+                Ok(500.0),
                 Duration::from_millis(12345),
             ),
             TestResult::new(
                 TestCase::new(2, NonZero::new(100), Objective::Max),
+                Err("error".to_string()),
                 Err("error".to_string()),
                 Duration::from_millis(1),
             ),

--- a/src/runner/multi/printer.rs
+++ b/src/runner/multi/printer.rs
@@ -28,7 +28,7 @@ impl Printer for ConsolePrinter {
         assert!(self.completed_count <= self.testcase_count);
 
         let score = result.score().as_ref().map(|s| s.get()).unwrap_or(0);
-        let comparative_score = result.relative_score().as_ref().copied().unwrap_or(0.0);
+        let comparative_score = result.comparative_score().as_ref().copied().unwrap_or(0.0);
         self.score_sum += score;
         self.comparative_score_sum += comparative_score;
 
@@ -83,7 +83,7 @@ impl Printer for ConsolePrinter {
             nonzero2,
         );
         let average_score_log10 = stats.score_sum_log10 / stats.results.len() as f64;
-        let average_comparative_score = stats.relative_score_sum / stats.results.len() as f64;
+        let average_comparative_score = stats.comparative_score_sum / stats.results.len() as f64;
         let ac_count =
             stats.results.len() - stats.results.iter().filter(|r| r.score().is_err()).count();
 
@@ -196,7 +196,7 @@ impl Printer for JsonPrinter {
             progress: self.completed_count,
             seed: result.test_case().seed(),
             score: result.score().as_ref().map(|s| s.get()).unwrap_or(0),
-            relative_score: result.relative_score().as_ref().copied().unwrap_or(0.0),
+            relative_score: result.comparative_score().as_ref().copied().unwrap_or(0.0),
             execution_time: result.execution_time().as_secs_f64(),
             error_message: result
                 .score()

--- a/src/runner/multi/printer.rs
+++ b/src/runner/multi/printer.rs
@@ -19,6 +19,7 @@ pub(super) struct ConsolePrinter {
     score_width: usize,
     score_sum: u64,
     relative_score_sum: f64,
+    comparative_label: &'static str,
 }
 
 impl Printer for ConsolePrinter {
@@ -90,7 +91,8 @@ impl Printer for ConsolePrinter {
         writeln!(writer, "Average Score (log10)  : {average_score_log10:.5}")?;
         writeln!(
             writer,
-            "Average Relative Score : {average_relative_score:.3}"
+            "Average {} Score : {average_relative_score:.3}",
+            self.comparative_label
         )?;
 
         let ac = format!("{} / {}", ac_count, stats.results.len());
@@ -118,7 +120,7 @@ impl Printer for ConsolePrinter {
 }
 
 impl ConsolePrinter {
-    pub(super) fn new(testcase_count: usize) -> Self {
+    pub(super) fn new(testcase_count: usize, comparative_label: &'static str) -> Self {
         assert!(testcase_count > 0);
 
         Self {
@@ -127,6 +129,7 @@ impl ConsolePrinter {
             score_width: 7,
             score_sum: 0,
             relative_score_sum: 0.0,
+            comparative_label,
         }
     }
 
@@ -153,7 +156,13 @@ impl ConsolePrinter {
         writeln!(
             writer,
             "| {:^test_width$} | {:^4} | {:^score_width2$} | {:^8} | {:^average_score_width2$} | {:^8} | {:^9} |",
-            "", "", "Score", "Relative", "Score", "Relative", "Time"
+            "",
+            "",
+            "Score",
+            self.comparative_label,
+            "Score",
+            self.comparative_label,
+            "Time"
         )?;
 
         let test_width = test_width + 2;
@@ -171,11 +180,16 @@ impl ConsolePrinter {
 
 pub(super) struct JsonPrinter {
     completed_count: usize,
+    #[allow(dead_code)]
+    comparative_label: &'static str,
 }
 
 impl JsonPrinter {
-    pub(super) fn new() -> Self {
-        Self { completed_count: 0 }
+    pub(super) fn new(comparative_label: &'static str) -> Self {
+        Self {
+            completed_count: 0,
+            comparative_label,
+        }
     }
 }
 
@@ -229,7 +243,7 @@ mod test {
     #[test]
     fn test_console_printer() {
         colored::control::set_override(true);
-        let mut printer = ConsolePrinter::new(3);
+        let mut printer = ConsolePrinter::new(3, "Relative");
 
         let test_results = gen_test_results();
         let mut buf = Box::new(vec![]);
@@ -270,7 +284,7 @@ Max Execution Time     : 12,345 ms
 
     #[test]
     fn test_json_printer() {
-        let mut printer = JsonPrinter::new();
+        let mut printer = JsonPrinter::new("Relative");
 
         let test_results = gen_test_results();
 

--- a/src/runner/multi/printer.rs
+++ b/src/runner/multi/printer.rs
@@ -180,16 +180,11 @@ impl ConsolePrinter {
 
 pub(super) struct JsonPrinter {
     completed_count: usize,
-    #[allow(dead_code)]
-    comparative_label: &'static str,
 }
 
 impl JsonPrinter {
-    pub(super) fn new(comparative_label: &'static str) -> Self {
-        Self {
-            completed_count: 0,
-            comparative_label,
-        }
+    pub(super) fn new() -> Self {
+        Self { completed_count: 0 }
     }
 }
 
@@ -284,7 +279,7 @@ Max Execution Time     : 12,345 ms
 
     #[test]
     fn test_json_printer() {
-        let mut printer = JsonPrinter::new("Relative");
+        let mut printer = JsonPrinter::new();
 
         let test_results = gen_test_results();
 

--- a/src/runner/multi/printer.rs
+++ b/src/runner/multi/printer.rs
@@ -18,7 +18,7 @@ pub(super) struct ConsolePrinter {
     completed_count: usize,
     score_width: usize,
     score_sum: u64,
-    relative_score_sum: f64,
+    comparative_score_sum: f64,
     comparative_label: &'static str,
 }
 
@@ -28,9 +28,9 @@ impl Printer for ConsolePrinter {
         assert!(self.completed_count <= self.testcase_count);
 
         let score = result.score().as_ref().map(|s| s.get()).unwrap_or(0);
-        let relative_score = result.relative_score().as_ref().copied().unwrap_or(0.0);
+        let comparative_score = result.relative_score().as_ref().copied().unwrap_or(0.0);
         self.score_sum += score;
-        self.relative_score_sum += relative_score;
+        self.comparative_score_sum += comparative_score;
 
         if self.completed_count == 1 {
             self.print_header(writer)?;
@@ -48,7 +48,7 @@ impl Printer for ConsolePrinter {
             .execution_time()
             .as_millis()
             .to_formatted_string(&Locale::en);
-        let average_relative_score = self.relative_score_sum / self.completed_count as f64;
+        let average_comparative_score = self.comparative_score_sum / self.completed_count as f64;
         self.score_width = self.score_width.max(score.len());
         let score_width = self.score_width;
         let average_score_width = score_width + 3;
@@ -59,9 +59,9 @@ impl Printer for ConsolePrinter {
             self.testcase_count,
             result.test_case().seed(),
             score,
-            relative_score,
+            comparative_score,
             average_score,
-            average_relative_score,
+            average_comparative_score,
             execution_time,
         );
 
@@ -83,7 +83,7 @@ impl Printer for ConsolePrinter {
             nonzero2,
         );
         let average_score_log10 = stats.score_sum_log10 / stats.results.len() as f64;
-        let average_relative_score = stats.relative_score_sum / stats.results.len() as f64;
+        let average_comparative_score = stats.relative_score_sum / stats.results.len() as f64;
         let ac_count =
             stats.results.len() - stats.results.iter().filter(|r| r.score().is_err()).count();
 
@@ -91,7 +91,7 @@ impl Printer for ConsolePrinter {
         writeln!(writer, "Average Score (log10)  : {average_score_log10:.5}")?;
         writeln!(
             writer,
-            "Average {} Score : {average_relative_score:.3}",
+            "Average {} Score : {average_comparative_score:.3}",
             self.comparative_label
         )?;
 
@@ -128,7 +128,7 @@ impl ConsolePrinter {
             completed_count: 0,
             score_width: 7,
             score_sum: 0,
-            relative_score_sum: 0.0,
+            comparative_score_sum: 0.0,
             comparative_label,
         }
     }

--- a/src/runner/single.rs
+++ b/src/runner/single.rs
@@ -1,3 +1,4 @@
+use super::comparative_score::ComparativeScoreCalculator;
 use anyhow::{Context, Result};
 use clap::ValueEnum;
 use regex::Regex;
@@ -7,6 +8,7 @@ use std::{
     fmt::Display,
     num::NonZeroU64,
     path::Path,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -38,17 +40,6 @@ impl TestCase {
             seed,
             reference_score,
             objective,
-        }
-    }
-
-    pub(super) fn calc_relative_score(&self, new_score: NonZeroU64) -> f64 {
-        let Some(old_score) = self.reference_score else {
-            return 100.0;
-        };
-
-        match self.objective {
-            Objective::Max => new_score.get() as f64 / old_score.get() as f64 * 100.0,
-            Objective::Min => old_score.get() as f64 / new_score.get() as f64 * 100.0,
         }
     }
 
@@ -84,10 +75,9 @@ impl TestResult {
     pub(super) fn new(
         test_case: TestCase,
         score: Result<NonZeroU64, String>,
+        relative_score: Result<f64, String>,
         execution_time: Duration,
     ) -> Self {
-        let relative_score = score.clone().map(|s| test_case.calc_relative_score(s));
-
         Self {
             test_case,
             score,
@@ -136,17 +126,23 @@ impl Display for Objective {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(super) struct SingleCaseRunner {
     steps: Vec<TestStep>,
     score_pattern: Regex,
+    comparative_score_calculator: Arc<dyn ComparativeScoreCalculator>,
 }
 
 impl SingleCaseRunner {
-    pub(super) const fn new(steps: Vec<TestStep>, score_pattern: Regex) -> Self {
+    pub(super) fn new(
+        steps: Vec<TestStep>,
+        score_pattern: Regex,
+        comparative_score_calculator: Arc<dyn ComparativeScoreCalculator>,
+    ) -> Self {
         Self {
             steps,
             score_pattern,
+            comparative_score_calculator,
         }
     }
 
@@ -165,9 +161,21 @@ impl SingleCaseRunner {
                     },
                     None => Err("Score not found".to_string()),
                 };
-                TestResult::new(test_case, score, execution_time)
+                let relative_score = score
+                    .as_ref()
+                    .map(|score| {
+                        self.comparative_score_calculator
+                            .calculate(test_case.seed, *score)
+                    })
+                    .map_err(Clone::clone);
+                TestResult::new(test_case, score, relative_score, execution_time)
             }
-            Err(e) => TestResult::new(test_case, Err(format!("{e:#}")), Duration::ZERO),
+            Err(e) => TestResult::new(
+                test_case,
+                Err(format!("{e:#}")),
+                Err(format!("{e:#}")),
+                Duration::ZERO,
+            ),
         }
     }
 
@@ -285,6 +293,7 @@ impl SingleCaseRunner {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runner::comparative_score::RelativeScoreCalculator;
 
     const TEST_CASE: TestCase = TestCase::new(42, None, Objective::Max);
     thread_local!(static SCORE_REGEX: Regex = Regex::new(r"^\s*Score\s*=\s*(?P<score>\d+)\s*$").unwrap());
@@ -312,17 +321,32 @@ mod test {
     }
 
     #[test]
-    fn test_calc_relative_score() {
+    fn test_result_relative_score() {
         let non_zero_100 = NonZeroU64::new(100).unwrap();
         let non_zero_200 = NonZeroU64::new(200).unwrap();
 
         let test_case = TestCase::new(0, Some(NonZeroU64::new(100).unwrap()), Objective::Max);
-        assert_eq!(test_case.calc_relative_score(non_zero_100), 100.0);
-        assert_eq!(test_case.calc_relative_score(non_zero_200), 200.0);
+        assert_eq!(
+            TestResult::new(test_case, Ok(non_zero_100), Ok(100.0), Duration::ZERO)
+                .relative_score(),
+            &Ok(100.0)
+        );
+        assert_eq!(
+            TestResult::new(test_case, Ok(non_zero_200), Ok(200.0), Duration::ZERO)
+                .relative_score(),
+            &Ok(200.0)
+        );
 
         let test_case = TestCase::new(0, Some(NonZeroU64::new(100).unwrap()), Objective::Min);
-        assert_eq!(test_case.calc_relative_score(non_zero_100), 100.0);
-        assert_eq!(test_case.calc_relative_score(non_zero_200), 50.0);
+        assert_eq!(
+            TestResult::new(test_case, Ok(non_zero_100), Ok(100.0), Duration::ZERO)
+                .relative_score(),
+            &Ok(100.0)
+        );
+        assert_eq!(
+            TestResult::new(test_case, Ok(non_zero_200), Ok(50.0), Duration::ZERO).relative_score(),
+            &Ok(50.0)
+        );
     }
 
     #[test]
@@ -355,7 +379,7 @@ mod test {
     #[test]
     fn run_test_ok() {
         let steps = vec![gen_teststep("echo", Some("Score = 1234"))];
-        let runner = SingleCaseRunner::new(steps, get_regex());
+        let runner = SingleCaseRunner::new(steps, get_regex(), get_calculator());
         let result = runner.run(TEST_CASE);
         assert_eq!(result.score(), &Ok(NonZeroU64::new(1234).unwrap()));
     }
@@ -363,7 +387,7 @@ mod test {
     #[test]
     fn run_test_score_zero() {
         let steps = vec![gen_teststep("echo", Some("Score = 0"))];
-        let runner = SingleCaseRunner::new(steps, get_regex());
+        let runner = SingleCaseRunner::new(steps, get_regex(), get_calculator());
         let result = runner.run(TEST_CASE);
 
         // 0点以下はWrong Answerとして扱う
@@ -373,7 +397,7 @@ mod test {
     #[test]
     fn run_test_fail() {
         let steps = vec![gen_teststep("false", None)];
-        let runner = SingleCaseRunner::new(steps, get_regex());
+        let runner = SingleCaseRunner::new(steps, get_regex(), get_calculator());
         let result = runner.run(TEST_CASE);
         assert!(result.score.is_err());
     }
@@ -381,7 +405,7 @@ mod test {
     #[test]
     fn run_test_invalid_output() {
         let steps = vec![gen_teststep("echo", Some("invalid_output"))];
-        let runner = SingleCaseRunner::new(steps, get_regex());
+        let runner = SingleCaseRunner::new(steps, get_regex(), get_calculator());
         let result = runner.run(TEST_CASE);
         assert!(result.score.is_err());
     }
@@ -393,5 +417,12 @@ mod test {
 
     fn get_regex() -> Regex {
         SCORE_REGEX.with(|r| r.clone())
+    }
+
+    fn get_calculator() -> Arc<dyn ComparativeScoreCalculator> {
+        Arc::new(RelativeScoreCalculator::new(
+            std::collections::HashMap::new(),
+            Objective::Max,
+        ))
     }
 }

--- a/src/runner/single.rs
+++ b/src/runner/single.rs
@@ -67,7 +67,7 @@ impl TestCase {
 pub(super) struct TestResult {
     test_case: TestCase,
     score: Result<NonZeroU64, String>,
-    relative_score: Result<f64, String>,
+    comparative_score: Result<f64, String>,
     execution_time: Duration,
 }
 
@@ -75,13 +75,13 @@ impl TestResult {
     pub(super) fn new(
         test_case: TestCase,
         score: Result<NonZeroU64, String>,
-        relative_score: Result<f64, String>,
+        comparative_score: Result<f64, String>,
         execution_time: Duration,
     ) -> Self {
         Self {
             test_case,
             score,
-            relative_score,
+            comparative_score,
             execution_time,
         }
     }
@@ -99,8 +99,8 @@ impl TestResult {
         self.score.as_ref().map(|s| (s.get() as f64).log10())
     }
 
-    pub(super) fn relative_score(&self) -> &Result<f64, String> {
-        &self.relative_score
+    pub(super) fn comparative_score(&self) -> &Result<f64, String> {
+        &self.comparative_score
     }
 
     pub(super) const fn execution_time(&self) -> Duration {
@@ -161,14 +161,14 @@ impl SingleCaseRunner {
                     },
                     None => Err("Score not found".to_string()),
                 };
-                let relative_score = score
+                let comparative_score = score
                     .as_ref()
                     .map(|score| {
                         self.comparative_score_calculator
                             .calculate(test_case.seed, *score)
                     })
                     .map_err(Clone::clone);
-                TestResult::new(test_case, score, relative_score, execution_time)
+                TestResult::new(test_case, score, comparative_score, execution_time)
             }
             Err(e) => TestResult::new(
                 test_case,
@@ -321,30 +321,31 @@ mod test {
     }
 
     #[test]
-    fn test_result_relative_score() {
+    fn test_result_comparative_score() {
         let non_zero_100 = NonZeroU64::new(100).unwrap();
         let non_zero_200 = NonZeroU64::new(200).unwrap();
 
         let test_case = TestCase::new(0, Some(NonZeroU64::new(100).unwrap()), Objective::Max);
         assert_eq!(
             TestResult::new(test_case, Ok(non_zero_100), Ok(100.0), Duration::ZERO)
-                .relative_score(),
+                .comparative_score(),
             &Ok(100.0)
         );
         assert_eq!(
             TestResult::new(test_case, Ok(non_zero_200), Ok(200.0), Duration::ZERO)
-                .relative_score(),
+                .comparative_score(),
             &Ok(200.0)
         );
 
         let test_case = TestCase::new(0, Some(NonZeroU64::new(100).unwrap()), Objective::Min);
         assert_eq!(
             TestResult::new(test_case, Ok(non_zero_100), Ok(100.0), Duration::ZERO)
-                .relative_score(),
+                .comparative_score(),
             &Ok(100.0)
         );
         assert_eq!(
-            TestResult::new(test_case, Ok(non_zero_200), Ok(50.0), Duration::ZERO).relative_score(),
+            TestResult::new(test_case, Ok(non_zero_200), Ok(50.0), Duration::ZERO)
+                .comparative_score(),
             &Ok(50.0)
         );
     }


### PR DESCRIPTION
## 概要

- `pahcer run` / `pahcer list` に `--rank` オプションを追加し、相対スコアに加えて順位スコアでも評価できるようにしました
- 比較スコア計算を `ComparativeScoreCalculator` として抽象化し、相対スコア・順位スコアの両方を扱えるようにしました
- README を更新し、あわせて依存クレートを更新しました

## 主な変更点

### 1. 順位スコア対応

- `RankScoreCalculator` を追加しました
- `pahcer run --rank`
  - 過去に保存された `./pahcer/json/result_*.json` を履歴として順位スコアを計算します
- `pahcer list --rank`
  - 保存済みの実行結果同士を比較して順位スコアを再計算します
- `run` / `list` の表示ラベルも切り替わるようにしました
  - `run --rank` では `Relative` 表示が `Rank` 表示になります
  - `list --rank` では `Avg Rel.` が `Avg Rank` になります
- 順位スコアの満点は `100` としました

### 2. 比較スコア計算の抽象化

- 比較スコア計算を `ComparativeScoreCalculator` トレイトとして抽象化しました
- `RelativeScoreCalculator` は既存の相対スコア計算を担う実装として維持しています
- 呼び出し側が具象型に依存しないよう、計算器の生成責務を上位側に寄せました
- `TestResult` は計算済みの比較スコアを保持するだけの形に整理しました

### 3. README 更新

- `--rank` オプションの説明を追加しました
- `run` / `list` の表示内容の違いを README に反映しました
- JSON フィールド名を互換性のため維持していることを追記しました

### 4. 依存クレート更新

- `cargo update` を実施し、`Cargo.lock` を更新しました
- あわせて `Cargo.toml` 上の依存バージョンも一部引き上げています
  - `mockall` 0.14
  - `rand` 0.10.1
  - `toml` 1.1.2
- その他の依存クレートも互換範囲内で更新されています

## 動作確認

- `cargo test` を実行し、全テストが通ることを確認しました
